### PR TITLE
Fixing gem dependencies

### DIFF
--- a/config_module.gemspec
+++ b/config_module.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+
+  gem.add_dependency 'pry'
   gem.add_development_dependency 'uspec'
-  gem.add_development_dependency 'pry'
   gem.add_development_dependency 'pry-theme'
 end

--- a/lib/config_module/version.rb
+++ b/lib/config_module/version.rb
@@ -1,3 +1,3 @@
 module ConfigModule
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
 Adding a non development dependency for pry gem since it is been used in ./lib/config_module.rb:3 which means it would blown when in non development environment
