### PR TITLE
Removing the require for Pry, since its only needed during debugging.

### DIFF
--- a/lib/config_module.rb
+++ b/lib/config_module.rb
@@ -1,6 +1,5 @@
 require 'ostruct'
 require 'yaml'
-require 'pry'
 
 require_relative 'config_module/version'
 require_relative 'config_module/exceptions'


### PR DESCRIPTION
Pry is only needed for development debugging, yet it was included in the main lib without catching `LoadError`s. In this case, the `require` can be removed without affecting the functionality at all.

Fixes #12 
