### PR TITLE
Setup block

### DIFF
--- a/lib/config_module.rb
+++ b/lib/config_module.rb
@@ -44,7 +44,7 @@ private
   def setup &block
     options = {
       method_name: 'config',
-      file_path: './config/settings.yml',
+      path: './config/settings.yml',
     }
 
     setup_dsl = Class.new do
@@ -52,8 +52,12 @@ private
         options[:method_name] = new_name
       end
 
-      def file_path new_path
-        options[:file_path] = new_path
+      def path new_path
+        options[:path] = new_path
+      end
+
+      def namespaces new_namespaces
+        options[:namespaces] = new_namespaces.flatten
       end
 
       def options
@@ -67,6 +71,17 @@ private
 
     Module.new do
       @options = options
+
+      define_method options[:method_name] do
+        __config_module_helper.config
+      end
+
+      def self.extended child
+        child.extend ConfigModule
+        helper = child.send(:__config_module_helper)
+        helper.config_file = @options[:path]
+        helper.namespaces  = @options[:namespaces]
+      end
     end
   end
 end

--- a/lib/config_module.rb
+++ b/lib/config_module.rb
@@ -38,4 +38,35 @@ private
   def method_missing name, *args, &block
     __config_module_helper.method_missing_handler name, caller(1), *args
   end
+
+  module_function
+
+  def setup &block
+    options = {
+      method_name: 'config',
+      file_path: './config/settings.yml',
+    }
+
+    setup_dsl = Class.new do
+      def method_name new_name
+        options[:method_name] = new_name
+      end
+
+      def file_path new_path
+        options[:file_path] = new_path
+      end
+
+      def options
+        @options ||= Hash.new
+      end
+    end
+
+    if block_given? then
+      options.merge! setup_dsl.new.tap{|dsl| dsl.instance_eval &block}.options
+    end
+
+    Module.new do
+      @options = options
+    end
+  end
 end

--- a/spec/config_setup_spec.rb
+++ b/spec/config_setup_spec.rb
@@ -4,11 +4,27 @@ require_relative 'example_config'
 spec 'able to set options using setup' do
   c = ConfigModule.setup do
     method_name :new_name
-    file_path :new_path
+    path 'new_path'
   end
 
-  expected = {method_name: :new_name, file_path: :new_path}
+  expected = {method_name: :new_name, path: 'new_path'}
   actual   = c.instance_variable_get(:@options)
 
   actual == expected || actual
+end
+
+spec 'setup method returns a module' do
+  c = ConfigModule.setup
+  c.class == Module
+end
+
+
+spec 'setup module can extend for full effect' do
+  m = Module.new
+  c = ConfigModule.setup do
+    path 'config/example.yml'
+  end
+  m.extend c
+
+  m.is_a? ConfigModule
 end

--- a/spec/config_setup_spec.rb
+++ b/spec/config_setup_spec.rb
@@ -1,0 +1,14 @@
+require_relative 'spec_helper'
+require_relative 'example_config'
+
+spec 'able to set options using setup' do
+  c = ConfigModule.setup do
+    method_name :new_name
+    file_path :new_path
+  end
+
+  expected = {method_name: :new_name, file_path: :new_path}
+  actual   = c.instance_variable_get(:@options)
+
+  actual == expected || actual
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'bundler/setup'
+require 'uspec'
+
 if ENV['CI'] == 'true' then
   require 'codeclimate-test-reporter'
   CodeClimate::TestReporter.start
@@ -6,8 +8,6 @@ if ENV['CI'] == 'true' then
     config.git_dir = `git rev-parse --show-toplevel`.strip
   end
 end
-require 'uspec'
-
 
 Dir.chdir File.dirname(__FILE__)
 


### PR DESCRIPTION
It works pretty much exactly like #11 demonstrated:

~~~ruby
module ExampleConfig
  extend ConfigModule.setup do
    path 'config/example.yml'
    namespace config_module.env
    method_name :settings
  end
end
~~~

The implementation needs some refactoring and the old usage needs to be deprecated before the next version.