### PR TITLE
Using absolute paths with require.

### DIFF
--- a/uspec/run_all_specs.rb
+++ b/uspec/run_all_specs.rb
@@ -1,5 +1,5 @@
 require_relative 'spec_helper'
 
 Dir['*_spec.rb'].each do |filename|
-  require_relative filename
+  require File.absolute_path(filename)
 end


### PR DESCRIPTION
This is due to Jruby having a hard time with require_relative, where MRI
has no trouble.