### PR TITLE
Fix various issues related to namespaces

### DIFF
--- a/lib/config_module/config_helper.rb
+++ b/lib/config_module/config_helper.rb
@@ -32,8 +32,8 @@ module ConfigModule
 
     def load_namespaces_from tree
       namespaces.inject(ConfigOption.wrap tree) do |subtree, ns|
-        if subtree.respond_to? ns then
-          subtree.send ns
+        if ConfigOption === subtree && ns.respond_to?(:to_sym) && subtree.has_key?(ns)
+          ConfigOption.wrap subtree[ns]
         else
           raise(
             InvalidNamespaceError.new(ns, subtree, caller),

--- a/lib/config_module/config_option.rb
+++ b/lib/config_module/config_option.rb
@@ -20,7 +20,7 @@ module ConfigModule
     end
 
     def has_key? key
-      @table.has_key? key
+      @table.has_key? key.to_sym
     end
 
     def method_missing name, *args, &block

--- a/uspec/config_helper_spec.rb
+++ b/uspec/config_helper_spec.rb
@@ -10,4 +10,3 @@ spec 'method_missing_handler traces back to the caller' do
     error.backtrace.to_s.include? "spec/config_helper_spec.rb:6:in"
   end
 end
-

--- a/uspec/config_option_spec.rb
+++ b/uspec/config_option_spec.rb
@@ -19,6 +19,10 @@ spec 'identifies the presence of keys' do
   opt.has_key? :a
 end
 
+spec 'identifies the presence of keys as strings' do
+  opt.has_key? 'a'
+end
+
 spec 'identifies the lack of keys' do
   opt.has_key?('nonexistant') == false
 end
@@ -34,4 +38,3 @@ spec 'to_ary' do
     error.class == ConfigModule::ConfigOption::NotFoundError
   end
 end
-

--- a/uspec/namespace_spec.rb
+++ b/uspec/namespace_spec.rb
@@ -22,6 +22,14 @@ spec 'specifying a namespace forces #config to return that subtree the first tim
   symbolized_keys_from_full_config == table.keys
 end
 
+spec 'nested namespaces are handled properly' do
+  helper = ConfigModule::ConfigHelper.new
+  helper.config_file = './config/example.yml'
+  helper.namespaces = ['production', 'dictionary']
+  helper.config.has_key?('configuration') &&
+    helper.config[:configuration] == helper.raw_config['production']['dictionary']['configuration']
+end
+
 spec 'misconfigured namespaces provide useful errors' do
   helper = ConfigModule::ConfigHelper.new
   helper.config_file = './config/example.yml'
@@ -32,6 +40,19 @@ spec 'misconfigured namespaces provide useful errors' do
   rescue ConfigModule::InvalidNamespaceError => error
     error.is_a?(ConfigModule::InvalidNamespaceError) &&
       error.message.include?('nonexistant') || error.message
+  end
+end
+
+spec 'out of bounds namespaces are checked properly' do
+  helper = ConfigModule::ConfigHelper.new
+  helper.config_file = './config/example.yml'
+  helper.namespaces = ['production', 'foo', 'bar']
+
+  begin
+    helper.config
+  rescue ConfigModule::InvalidNamespaceError => error
+    error.is_a?(ConfigModule::InvalidNamespaceError) &&
+      error.message.include?('bar') || error.message
   end
 end
 


### PR DESCRIPTION
- Switched the namespace lookup code to use keys rather than send. This
  makes it possible to have namespace values that might also have a
  method of the same name (seen in weird Ruby 2.3.3 bug).
- ConfigOption#has_key? wasn't converting to Symbol before checking.
- Added some tests.