### PR TITLE
Compatibility fixes

### DIFF
--- a/lib/config_module/config_option.rb
+++ b/lib/config_module/config_option.rb
@@ -2,28 +2,43 @@
 
 module ConfigModule
   class ConfigOption < OpenStruct
-    include Enumerable
-
     def self.wrap data
       if data.is_a? Hash
-        ConfigOption.new data
+        new data
       else
         data
       end
     end
 
-    def each
-      return to_enum __method__ unless block_given?
-      @table.each_pair { |p| yield p }
+    def each_pair
+      return to_enum(__method__) { @table.size } unless block_given?
+      @table.each_pair { |pair| yield pair }
+      self
+    end
+    alias each each_pair
+
+    def each_key
+      return to_enum(__method__) { @table.size } unless block_given?
+      @table.each_key { |key| yield key }
+      self
     end
 
-    def [] name
-      @table[name.to_sym]
+    def each_value
+      return to_enum(__method__) { @table.size } unless block_given?
+      @table.each_value { |value| yield value }
+      self
+    end
+
+    unless public_instance_method :[]
+      def [] name
+        @table[name.to_sym]
+      end
     end
 
     def has_key? key
       @table.has_key? key.to_sym
     end
+    alias key? has_key?
 
     def method_missing name, *args, &block
       result = super
@@ -36,7 +51,6 @@ module ConfigModule
           "Key not found: #{name}", caller(3)
         )
       end
-
     rescue NoMethodError => error
       raise(
         ConfigOption::NotFoundError.new(name, self, error),
@@ -44,21 +58,40 @@ module ConfigModule
       )
     end
 
-    def respond_to_missing? name, include_all
-      @table.has_key?(name) || super
-    end
-
-    def new_ostruct_member name
-      name = name.to_sym
-      unless respond_to? name
-        define_singleton_method(name) { self.class.wrap @table[name] }
-        define_singleton_method("#{name}=") { |x| modifiable[name] = x }
+    if private_instance_methods.include? :new_ostruct_member!
+      # :reek:TooManyStatements { max_statements: 10 }
+      def new_ostruct_member! name
+        name = name.to_sym
+        unless singleton_class.method_defined? name
+          define_singleton_method(name) { self.class.wrap @table[name] }
+          define_singleton_method("#{name}=") { |val| modifiable[name] = val }
+        end
+        name
       end
-      name
+      private :new_ostruct_member!
+      alias new_ostruct_member new_ostruct_member! # :nodoc:
+      protected :new_ostruct_member
+    elsif instance_methods.include? :new_ostruct_member
+      # :reek:TooManyStatements { max_statements: 10 }
+      def new_ostruct_member name
+        name = name.to_sym
+        unless respond_to? name
+          define_singleton_method(name) { self.class.wrap @table[name] }
+          define_singleton_method("#{name}=") { |val| modifiable[name] = val }
+        end
+        name
+      end
+      protected :new_ostruct_member
     end
 
     class NotFoundError < ::ConfigModule::ConfigError
       def identifier; :key; end
+    end
+
+  private
+
+    def respond_to_missing? name, include_all
+      @table.has_key?(name) || super
     end
   end
 end

--- a/uspec/config_option_spec.rb
+++ b/uspec/config_option_spec.rb
@@ -13,8 +13,60 @@ spec "#[] returns value associated with key" do
   opt[:a] == hash[:a]
 end
 
-spec "ConfigOptions are Enumerable" do
-  opt.map { |_, v| v[:b] } == [5]
+spec "supports each" do
+  x = []
+  opt.each { |k, v| x << [k, v] } == opt && x == [[:a, { b: 5 }]]
+end
+
+spec "supports each_pair" do
+  x = []
+  opt.each_pair { |k, v| x << [k, v] } == opt && x == [[:a, { b: 5 }]]
+end
+
+spec "supports each_key" do
+  x = []
+  opt.each_key { |k| x << k } == opt && x == [:a]
+end
+
+spec "supports each_value" do
+  x = []
+  opt.each_value { |v| x << v } == opt && x == [{ b: 5 }]
+end
+
+spec "supports each as enumerator" do
+  opt.each.class == Enumerator && opt.each.to_a == [[:a, { b: 5 }]]
+end
+
+spec "supports each_pair as enumerator" do
+  opt.each_pair.class == Enumerator && opt.each_pair.to_a == [[:a, { b: 5 }]]
+end
+
+spec "supports each_key as enumerator" do
+  opt.each_key.class == Enumerator && opt.each_key.to_a == [:a]
+end
+
+spec "supports each_value as enumerator" do
+  opt.each_value.class == Enumerator && opt.each_value.to_a == [{ b: 5 }]
+end
+
+spec "can be frozen" do
+  frozen = opt.dup.freeze
+  frozen.frozen?
+end
+
+spec "when frozen, defines methods which return the right results" do
+  frozen = opt.dup.freeze
+  frozen.a.class == ConfigModule::ConfigOption
+end
+
+spec "when frozen, does not freeze nested options" do
+  frozen = opt.dup.freeze
+  !frozen.a.frozen?
+end
+
+spec "when frozen, nested options still work" do
+  frozen = opt.dup.freeze
+  frozen.a.b == 5
 end
 
 spec "identifies the presence of keys" do


### PR DESCRIPTION
- Don't define things that are already defined as the same thing.
- Return enumerators instead of including Enumerable.
- Alias has_key? as key?.
- Make sure freezing works in both old and new Ruby versions.

[Fixes #16]