### PR TITLE
Fixes for 1.x

### DIFF
--- a/lib/config_module/config_option.rb
+++ b/lib/config_module/config_option.rb
@@ -2,6 +2,8 @@
 
 module ConfigModule
   class ConfigOption < OpenStruct
+    include Enumerable
+
     def self.wrap data
       if data.is_a? Hash
         new data
@@ -58,6 +60,11 @@ module ConfigModule
       )
     end
 
+    def respond_to_missing? name, include_all
+      @table.has_key?(name) || super
+    end
+    private :respond_to_missing?
+
     if private_instance_methods.include? :new_ostruct_member!
       # :reek:TooManyStatements { max_statements: 10 }
       def new_ostruct_member! name
@@ -84,12 +91,6 @@ module ConfigModule
       protected :new_ostruct_member
     end
 
-  private
-
-    def respond_to_missing? name, include_all
-      @table.has_key?(name) || super
-    end
-    
     class NotFoundError < ::ConfigModule::ConfigError
       def identifier; :key; end
     end

--- a/uspec/config_option_spec.rb
+++ b/uspec/config_option_spec.rb
@@ -5,6 +5,10 @@ require_relative "spec_helper"
 hash = { a: { b: 5 } }
 opt = ConfigModule::ConfigOption.new hash
 
+spec "includes Enumerable (deprecated)" do
+  ConfigModule::ConfigOption.include?(Enumerable)
+end
+
 spec "responds to #[]" do
   opt.respond_to? :[]
 end


### PR DESCRIPTION
- Restores Enumerable for 1.x compatibility.
- Makes sure the method visibility hasn't changed.